### PR TITLE
Remove unexported library

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,5 +1,6 @@
 name: Build and Test
 on:
+  workflow_dispatch:
   pull_request:
     branches: [ main ]
   push:
@@ -8,11 +9,14 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - name: Checking out
+      - name: Checkout this repository
         uses: actions/checkout@v2.3.4
-      - name: Building and testing
-        uses: ichiro-its/ros2-ci@v1.0.0
         with:
-          ros2-distro: foxy
-          pre-install: sudo apt update && sudo apt install -y curl && curl -s http://repository.ichiro-its.org/debian/setup.bash | bash -s
-          apt-packages: ros-foxy-keisan
+          path: tosshin
+      - name: Add Debian repository and rosdep sources list
+        run: |
+          sudo apt update && sudo apt install curl
+          curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
+          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+      - name: Build and test workspace
+        uses: ichiro-its/ros2-build-and-test-action@main

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,8 @@ jobs:
           path: tosshin
       - name: Add Debian repository and rosdep sources list
         run: |
-          sudo apt update && sudo apt install curl
+          sudo apt update && sudo apt install curl python3-rosdep
+          sudo rosdep init || true
           curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
           curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
       - name: Build and test workspace

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,8 +15,7 @@ jobs:
           path: tosshin
       - name: Add Debian repository and rosdep sources list
         run: |
-          sudo apt update && sudo apt install curl python3-rosdep
-          sudo rosdep init || true
+          sudo apt update && sudo apt install curl
           curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
           curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
       - name: Build and test workspace

--- a/tosshin_cpp/CMakeLists.txt
+++ b/tosshin_cpp/CMakeLists.txt
@@ -43,6 +43,5 @@ endif()
 
 ament_export_dependencies(keisan rclcpp tosshin_interfaces)
 ament_export_include_directories("include")
-ament_export_libraries(${PROJECT_NAME})
 
 ament_package()


### PR DESCRIPTION
- Remove export library in the `CMakeLists.txt`.
- Modify the build and test workflow.