### PR TITLE
fix: build library as a shared lib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ endforeach()
 
 install(DIRECTORY "include" DESTINATION ".")
 
-add_library(${PROJECT_NAME}
+add_library(${PROJECT_NAME} SHARED
   "src/conversion.cpp")
 
 ament_target_dependencies(${PROJECT_NAME} ${DEPENDENCIES})


### PR DESCRIPTION
Change the library into a shared library to fix dependency problems.