### PR TITLE
fix(ci): resolve build failures from dead domain and keisan API break

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,16 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
           path: tosshin
 
-      - name: Add Debian repositories and rosdep sources list
-        run: |
-          sudo apt update && sudo apt install curl
-          curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
-          curl -s http://repository.ichiro-its.org/debian/setup-threeal.bash | bash -s
-          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+      - name: Checkout keisan dependency
+        uses: actions/checkout@v4
+        with:
+          repository: ichiro-its/keisan
+          ref: 593c9dce7acf322db4e13a3d15d628de3e7186be
+          path: keisan
 
       - name: Build and test workspace
         uses: ichiro-its/ros2-build-and-test-action@main
+        with:
+          distro: iron

--- a/.github/workflows/deploy-debian.yml
+++ b/.github/workflows/deploy-debian.yml
@@ -8,24 +8,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
         with:
           path: tosshin
 
-      - name: Add Debian repositories and rosdep sources list
-        run: |
-          sudo apt update && sudo apt install curl
-          curl -s http://repository.ichiro-its.org/debian/setup-nightly.bash | bash -s
-          curl -s http://repository.ichiro-its.org/debian/setup-threeal.bash | bash -s
-          curl -s http://repository.ichiro-its.org/rosdep/setup.bash | bash -s
+      - name: Checkout keisan dependency
+        uses: actions/checkout@v4
+        with:
+          repository: ichiro-its/keisan
+          ref: 593c9dce7acf322db4e13a3d15d628de3e7186be
+          path: keisan
 
       - name: Build Debian package
         uses: ichiro-its/ros2-build-debian-action@main
         with:
+          ros2-distro: iron
           unique-version: true
 
       - name: Deploy Debian package to server
-        uses: appleboy/scp-action@master
+        uses: appleboy/scp-action@v0.1.7
         with:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}
@@ -36,7 +37,7 @@ jobs:
           rm: true
 
       - name: Prepare Debian package in the server
-        uses: appleboy/ssh-action@master
+        uses: appleboy/ssh-action@v1.0.3
         with:
           host: ${{ secrets.SSH_HOST }}
           port: ${{ secrets.SSH_PORT }}

--- a/.github/workflows/deploy-documentation.yml
+++ b/.github/workflows/deploy-documentation.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout this repository
-        uses: actions/checkout@v2.3.4
+        uses: actions/checkout@v4
 
       - name: Build documentation
         uses: mattnotmitt/doxygen-action@v1.3.1


### PR DESCRIPTION
## Summary

Fixes all identified CI build failures in the tosshin project. The repository has been dormant since 2021-06-28, and multiple external dependencies have broken since then.

## Root Causes Fixed

| # | Issue | Fix |
|---|-------|-----|
| 1 | `repository.ichiro-its.org` DNS is dead (curl exit code 6) | Removed dead setup steps entirely |
| 2 | `keisan` not in standard rosdep database | Added keisan as a workspace source dependency via `actions/checkout` |
| 3 | keisan's `Quaternion` was converted to `Quaternion<T>` template (2021-08-28), breaking tosshin's non-templated usage | Pinned keisan to commit `593c9dc` (last pre-template version) |
| 4 | CI action defaults to ROS 2 `iron` but no distro was specified | Explicitly set `distro: iron` |
| 5 | Outdated GitHub Actions versions | Updated checkout, scp-action, ssh-action to current versions |

## Changes

### `.github/workflows/build-and-test.yml`
- `actions/checkout@v2.3.4` → `@v4`
- Removed 3 dead `curl | bash` steps for `repository.ichiro-its.org`
- Added `actions/checkout@v4` step to clone `ichiro-its/keisan` at pinned commit `593c9dc`
- Added explicit `distro: iron` input to `ichiro-its/ros2-build-and-test-action`

### `.github/workflows/deploy-debian.yml`
- Same keisan checkout and dead-domain removal as above
- Added explicit `ros2-distro: iron` input to `ros2-build-debian-action`
- `appleboy/scp-action@master` → `@v0.1.7`
- `appleboy/ssh-action@master` → `@v1.0.3`

### `.github/workflows/deploy-documentation.yml`
- `actions/checkout@v2.3.4` → `@v4`

## How It Works

The `ichiro-its/ros2-build-and-test-action` internally runs:
```
rosdep install --from-paths . --ignore-src
```
The `--ignore-src` flag means packages already in the workspace (keisan + tosshin) are **not** looked up in rosdep — they're built from source by `colcon build`. This eliminates the need for the dead custom Debian/rosdep repositories.

## Known Remaining Risks

1. **Deploy workflow SSH server** — The deploy-debian workflow SCPs to a server via SSH secrets. If `repository.ichiro-its.org` is dead, the SSH server is likely also unreachable. The team should verify `secrets.SSH_HOST` or disable the deploy workflow.
2. **`libargparse-dev`** — Listed in `package.xml` but not in standard rosdep. It IS available as an Ubuntu apt package, so rosdep should resolve it via apt fallback. If this fails, it can be added to a custom rosdep source.
3. **Future keisan updates** — The keisan pin means tosshin won't get keisan bug fixes. Long-term, tosshin's code should be updated to use `keisan::Quaternion<double>` instead of `keisan::Quaternion` (see Phase 2 Option B in the analysis).

## Verification

Push this PR to trigger the `Build and Test` workflow. Expected result:
- ✅ keisan checked out at `593c9dc`
- ✅ rosdep resolves all deps (keisan skipped via `--ignore-src`)
- ✅ `colcon build` compiles both keisan and tosshin
- ✅ `colcon test` passes gtest and lint checks